### PR TITLE
Remove useless informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@ Targets 64-bit x86 on linux, specifically gcc.
 
 The compiler uses a fixed-size array of 4000 elements for the cells.
 
-## Performance
-
-It's assembly, so probably faster than C.
-
-## Benchmarks
-
-Run your own.
-
 ## Optimizations
 
 This is not (yet) an optimizing compiler.


### PR DESCRIPTION
Also, assembly doesn't mean fast code. FYI gcc compiles C to assembly so saying "assembly is faster than C" doesn't even make sense.